### PR TITLE
Add filtered search view for cerveza and existencia

### DIFF
--- a/src/main/java/org/cerveza/cerveza/controller/MainController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/MainController.java
@@ -34,6 +34,7 @@ public class MainController {
     @FXML public void openPresentacionForm()  { setCenter("/fxml/presentacion-form.fxml"); }
     @FXML public void openRecetaForm()  { setCenter("/fxml/receta-form.fxml"); }
     @FXML public void openVentaForm()  { setCenter("/fxml/venta-form.fxml"); }
+    @FXML public void openSearchView() { setCenter("/fxml/search-view.fxml"); }
 
     private void setCenter(String absoluteFxmlPath) {
         try {

--- a/src/main/java/org/cerveza/cerveza/controller/SearchController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/SearchController.java
@@ -1,0 +1,303 @@
+package org.cerveza.cerveza.controller;
+
+import javafx.beans.value.ChangeListener;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.scene.control.cell.PropertyValueFactory;
+import org.cerveza.cerveza.dao.CervezaDao;
+import org.cerveza.cerveza.dao.ExistenciaDao;
+import org.cerveza.cerveza.dao.impl.CervezaDaoImpl;
+import org.cerveza.cerveza.dao.impl.ExistenciaDaoImpl;
+import org.cerveza.cerveza.model.Cerveza;
+import org.cerveza.cerveza.model.Existencia;
+
+import java.time.LocalDate;
+import java.util.function.UnaryOperator;
+
+public class SearchController {
+
+    // --- Cerveza ---
+    @FXML private TextField txtCervezaId;
+    @FXML private TextField txtCervezaIdMarca;
+    @FXML private TextField txtCervezaNombre;
+    @FXML private TextField txtCervezaAspecto;
+    @FXML private TextField txtCervezaProcedimientos;
+    @FXML private TextField txtCervezaGradMin;
+    @FXML private TextField txtCervezaGradMax;
+    @FXML private TextField txtCervezaExistMin;
+    @FXML private TextField txtCervezaExistMax;
+    @FXML private TableView<Cerveza> tblCervezas;
+    @FXML private TableColumn<Cerveza, Integer> colCerId;
+    @FXML private TableColumn<Cerveza, Integer> colCerIdMarca;
+    @FXML private TableColumn<Cerveza, String> colCerNombre;
+    @FXML private TableColumn<Cerveza, String> colCerAspecto;
+    @FXML private TableColumn<Cerveza, String> colCerProcedimientos;
+    @FXML private TableColumn<Cerveza, Double> colCerGraduacion;
+    @FXML private TableColumn<Cerveza, Integer> colCerExistTotal;
+
+    // --- Existencia ---
+    @FXML private TextField txtExistId;
+    @FXML private TextField txtExistIdExpendio;
+    @FXML private TextField txtExistNombreExpendio;
+    @FXML private TextField txtExistIdPresentacion;
+    @FXML private TextField txtExistNombrePresentacion;
+    @FXML private TextField txtExistCantidadMin;
+    @FXML private TextField txtExistCantidadMax;
+    @FXML private DatePicker dpExistFechaDesde;
+    @FXML private DatePicker dpExistFechaHasta;
+    @FXML private TableView<Existencia> tblExistencias;
+    @FXML private TableColumn<Existencia, Integer> colExistId;
+    @FXML private TableColumn<Existencia, Integer> colExistIdExpendio;
+    @FXML private TableColumn<Existencia, String> colExistNombreExpendio;
+    @FXML private TableColumn<Existencia, Integer> colExistIdPresentacion;
+    @FXML private TableColumn<Existencia, String> colExistNombrePresentacion;
+    @FXML private TableColumn<Existencia, Integer> colExistCantidad;
+    @FXML private TableColumn<Existencia, LocalDate> colExistFecha;
+
+    private final CervezaDao cervezaDao = new CervezaDaoImpl();
+    private final ExistenciaDao existenciaDao = new ExistenciaDaoImpl();
+
+    private final ObservableList<Cerveza> cervezaMaster = FXCollections.observableArrayList();
+    private final FilteredList<Cerveza> cervezaFiltered = new FilteredList<>(cervezaMaster, c -> true);
+
+    private final ObservableList<Existencia> existenciaMaster = FXCollections.observableArrayList();
+    private final FilteredList<Existencia> existenciaFiltered = new FilteredList<>(existenciaMaster, e -> true);
+
+    @FXML
+    public void initialize() {
+        configureNumericTextField(txtCervezaId, false);
+        configureNumericTextField(txtCervezaIdMarca, false);
+        configureNumericTextField(txtCervezaGradMin, true);
+        configureNumericTextField(txtCervezaGradMax, true);
+        configureNumericTextField(txtCervezaExistMin, false);
+        configureNumericTextField(txtCervezaExistMax, false);
+
+        configureNumericTextField(txtExistId, false);
+        configureNumericTextField(txtExistIdExpendio, false);
+        configureNumericTextField(txtExistIdPresentacion, false);
+        configureNumericTextField(txtExistCantidadMin, false);
+        configureNumericTextField(txtExistCantidadMax, false);
+
+        setupCervezaTable();
+        setupExistenciaTable();
+
+        loadCervezaData();
+        loadExistenciaData();
+
+        registerCervezaFilterListeners();
+        registerExistenciaFilterListeners();
+    }
+
+    private void setupCervezaTable() {
+        colCerId.setCellValueFactory(new PropertyValueFactory<>("id"));
+        colCerIdMarca.setCellValueFactory(new PropertyValueFactory<>("idMarca"));
+        colCerNombre.setCellValueFactory(new PropertyValueFactory<>("nombre"));
+        colCerAspecto.setCellValueFactory(new PropertyValueFactory<>("aspecto"));
+        colCerProcedimientos.setCellValueFactory(new PropertyValueFactory<>("procedimientos"));
+        colCerGraduacion.setCellValueFactory(new PropertyValueFactory<>("graduacion"));
+        colCerExistTotal.setCellValueFactory(new PropertyValueFactory<>("existenciaTotal"));
+        tblCervezas.setItems(cervezaFiltered);
+        tblCervezas.setPlaceholder(new Label("No hay resultados para mostrar"));
+    }
+
+    private void setupExistenciaTable() {
+        colExistId.setCellValueFactory(new PropertyValueFactory<>("idExistencia"));
+        colExistIdExpendio.setCellValueFactory(new PropertyValueFactory<>("idExpendio"));
+        colExistNombreExpendio.setCellValueFactory(new PropertyValueFactory<>("expendioNombre"));
+        colExistIdPresentacion.setCellValueFactory(new PropertyValueFactory<>("idPresentacion"));
+        colExistNombrePresentacion.setCellValueFactory(new PropertyValueFactory<>("presentacionNombre"));
+        colExistCantidad.setCellValueFactory(new PropertyValueFactory<>("cantidad"));
+        colExistFecha.setCellValueFactory(new PropertyValueFactory<>("fecha"));
+        tblExistencias.setItems(existenciaFiltered);
+        tblExistencias.setPlaceholder(new Label("No hay resultados para mostrar"));
+    }
+
+    private void registerCervezaFilterListeners() {
+        ChangeListener<String> listener = (obs, oldValue, newValue) -> updateCervezaFilter();
+        txtCervezaId.textProperty().addListener(listener);
+        txtCervezaIdMarca.textProperty().addListener(listener);
+        txtCervezaNombre.textProperty().addListener(listener);
+        txtCervezaAspecto.textProperty().addListener(listener);
+        txtCervezaProcedimientos.textProperty().addListener(listener);
+        txtCervezaGradMin.textProperty().addListener(listener);
+        txtCervezaGradMax.textProperty().addListener(listener);
+        txtCervezaExistMin.textProperty().addListener(listener);
+        txtCervezaExistMax.textProperty().addListener(listener);
+    }
+
+    private void registerExistenciaFilterListeners() {
+        ChangeListener<String> listener = (obs, oldValue, newValue) -> updateExistenciaFilter();
+        txtExistId.textProperty().addListener(listener);
+        txtExistIdExpendio.textProperty().addListener(listener);
+        txtExistNombreExpendio.textProperty().addListener(listener);
+        txtExistIdPresentacion.textProperty().addListener(listener);
+        txtExistNombrePresentacion.textProperty().addListener(listener);
+        txtExistCantidadMin.textProperty().addListener(listener);
+        txtExistCantidadMax.textProperty().addListener(listener);
+        dpExistFechaDesde.valueProperty().addListener((obs, oldValue, newValue) -> updateExistenciaFilter());
+        dpExistFechaHasta.valueProperty().addListener((obs, oldValue, newValue) -> updateExistenciaFilter());
+    }
+
+    private void configureNumericTextField(TextField field, boolean allowDecimal) {
+        UnaryOperator<TextFormatter.Change> filter = change -> {
+            String newText = change.getControlNewText();
+            if (newText.isEmpty()) return change;
+            String pattern = allowDecimal ? "-?\\d*(?:[.]\\d*)?" : "-?\\d*";
+            return newText.matches(pattern) ? change : null;
+        };
+        field.setTextFormatter(new TextFormatter<>(filter));
+    }
+
+    private void loadCervezaData() {
+        cervezaMaster.setAll(cervezaDao.findAll());
+        updateCervezaFilter();
+    }
+
+    private void loadExistenciaData() {
+        existenciaMaster.setAll(existenciaDao.findAllWithLabels());
+        updateExistenciaFilter();
+    }
+
+    private void updateCervezaFilter() {
+        cervezaFiltered.setPredicate(cerveza -> {
+            if (cerveza == null) return false;
+
+            Integer idFilter = parseInteger(txtCervezaId);
+            if (idFilter != null && !idFilter.equals(cerveza.getId())) return false;
+
+            Integer idMarcaFilter = parseInteger(txtCervezaIdMarca);
+            if (idMarcaFilter != null && !idMarcaFilter.equals(cerveza.getIdMarca())) return false;
+
+            String nombreFilter = normalize(txtCervezaNombre.getText());
+            if (!nombreFilter.isEmpty() && !containsIgnoreCase(cerveza.getNombre(), nombreFilter)) return false;
+
+            String aspectoFilter = normalize(txtCervezaAspecto.getText());
+            if (!aspectoFilter.isEmpty() && !containsIgnoreCase(cerveza.getAspecto(), aspectoFilter)) return false;
+
+            String procFilter = normalize(txtCervezaProcedimientos.getText());
+            if (!procFilter.isEmpty() && !containsIgnoreCase(cerveza.getProcedimientos(), procFilter)) return false;
+
+            Double gradMin = parseDouble(txtCervezaGradMin);
+            if (gradMin != null) {
+                Double grad = cerveza.getGraduacion();
+                if (grad == null || grad < gradMin) return false;
+            }
+
+            Double gradMax = parseDouble(txtCervezaGradMax);
+            if (gradMax != null) {
+                Double grad = cerveza.getGraduacion();
+                if (grad == null || grad > gradMax) return false;
+            }
+
+            Integer existMin = parseInteger(txtCervezaExistMin);
+            if (existMin != null) {
+                Integer total = cerveza.getExistenciaTotal();
+                if (total == null || total < existMin) return false;
+            }
+
+            Integer existMax = parseInteger(txtCervezaExistMax);
+            if (existMax != null) {
+                Integer total = cerveza.getExistenciaTotal();
+                if (total == null || total > existMax) return false;
+            }
+
+            return true;
+        });
+    }
+
+    private void updateExistenciaFilter() {
+        existenciaFiltered.setPredicate(existencia -> {
+            if (existencia == null) return false;
+
+            Integer idFilter = parseInteger(txtExistId);
+            if (idFilter != null && existencia.getIdExistencia() != idFilter) return false;
+
+            Integer idExpFilter = parseInteger(txtExistIdExpendio);
+            if (idExpFilter != null && existencia.getIdExpendio() != idExpFilter) return false;
+
+            String expNombreFilter = normalize(txtExistNombreExpendio.getText());
+            if (!expNombreFilter.isEmpty() && !containsIgnoreCase(existencia.getExpendioNombre(), expNombreFilter)) return false;
+
+            Integer idPresFilter = parseInteger(txtExistIdPresentacion);
+            if (idPresFilter != null && existencia.getIdPresentacion() != idPresFilter) return false;
+
+            String presNombreFilter = normalize(txtExistNombrePresentacion.getText());
+            if (!presNombreFilter.isEmpty() && !containsIgnoreCase(existencia.getPresentacionNombre(), presNombreFilter)) return false;
+
+            Integer cantidadMin = parseInteger(txtExistCantidadMin);
+            if (cantidadMin != null && existencia.getCantidad() < cantidadMin) return false;
+
+            Integer cantidadMax = parseInteger(txtExistCantidadMax);
+            if (cantidadMax != null && existencia.getCantidad() > cantidadMax) return false;
+
+            LocalDate desde = dpExistFechaDesde.getValue();
+            if (desde != null && existencia.getFecha().isBefore(desde)) return false;
+
+            LocalDate hasta = dpExistFechaHasta.getValue();
+            if (hasta != null && existencia.getFecha().isAfter(hasta)) return false;
+
+            return true;
+        });
+    }
+
+    private Integer parseInteger(TextField field) {
+        String value = field.getText();
+        if (value == null || value.isBlank()) return null;
+        return Integer.parseInt(value);
+    }
+
+    private Double parseDouble(TextField field) {
+        String value = field.getText();
+        if (value == null || value.isBlank()) return null;
+        return Double.parseDouble(value);
+    }
+
+    private String normalize(String text) {
+        return text == null ? "" : text.trim().toLowerCase();
+    }
+
+    private boolean containsIgnoreCase(String source, String filter) {
+        return source != null && source.toLowerCase().contains(filter);
+    }
+
+    @FXML
+    private void onLimpiarFiltrosCerveza() {
+        txtCervezaId.clear();
+        txtCervezaIdMarca.clear();
+        txtCervezaNombre.clear();
+        txtCervezaAspecto.clear();
+        txtCervezaProcedimientos.clear();
+        txtCervezaGradMin.clear();
+        txtCervezaGradMax.clear();
+        txtCervezaExistMin.clear();
+        txtCervezaExistMax.clear();
+        updateCervezaFilter();
+    }
+
+    @FXML
+    private void onLimpiarFiltrosExistencia() {
+        txtExistId.clear();
+        txtExistIdExpendio.clear();
+        txtExistNombreExpendio.clear();
+        txtExistIdPresentacion.clear();
+        txtExistNombrePresentacion.clear();
+        txtExistCantidadMin.clear();
+        txtExistCantidadMax.clear();
+        dpExistFechaDesde.setValue(null);
+        dpExistFechaHasta.setValue(null);
+        updateExistenciaFilter();
+    }
+
+    @FXML
+    private void onRecargarCervezas() {
+        loadCervezaData();
+    }
+
+    @FXML
+    private void onRecargarExistencias() {
+        loadExistenciaData();
+    }
+}

--- a/src/main/resources/fxml/main.fxml
+++ b/src/main/resources/fxml/main.fxml
@@ -32,6 +32,12 @@
                         </items>
                     </Menu>
 
+                    <Menu text="_Consultas" mnemonicParsing="true">
+                        <items>
+                            <MenuItem text="Buscador" onAction="#openSearchView" accelerator="Ctrl+F"/>
+                        </items>
+                    </Menu>
+
                     <Menu text="_Ayuda" mnemonicParsing="true">
                         <items>
                             <MenuItem text="Acerca de" onAction="#onAcercaDe" accelerator="F1"/>
@@ -55,6 +61,7 @@
                 <Button onAction="#openPresentacionForm" text="Presentación"/>
                 <Button onAction="#openRecetaForm"       text="Receta"/>
                 <Button onAction="#openVentaForm"        text="Venta"/>
+                <Button onAction="#openSearchView"      text="Buscador"/>
 
                 <Separator/>
 

--- a/src/main/resources/fxml/search-view.fxml
+++ b/src/main/resources/fxml/search-view.fxml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx/17.0.12"
+            xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="org.cerveza.cerveza.controller.SearchController">
+    <children>
+        <VBox spacing="16" AnchorPane.topAnchor="0" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0" styleClass="card">
+            <Label text="Buscador" styleClass="h1"/>
+            <TabPane tabClosingPolicy="UNAVAILABLE">
+                <tabs>
+                    <Tab text="Cervezas">
+                        <content>
+                            <VBox spacing="12">
+                                <padding>
+                                    <Insets top="10" right="10" bottom="10" left="10"/>
+                                </padding>
+                                <GridPane hgap="10" vgap="10">
+                                    <columnConstraints>
+                                        <ColumnConstraints percentWidth="25"/>
+                                        <ColumnConstraints percentWidth="75"/>
+                                    </columnConstraints>
+
+                                    <Label text="ID" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtCervezaId" promptText="Exacto" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+
+                                    <Label text="ID Marca" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtCervezaIdMarca" promptText="Exacto" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+
+                                    <Label text="Nombre" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtCervezaNombre" promptText="Contiene" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+
+                                    <Label text="Aspecto" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtCervezaAspecto" promptText="Contiene" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
+
+                                    <Label text="Procedimientos" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtCervezaProcedimientos" promptText="Contiene" GridPane.rowIndex="4" GridPane.columnIndex="1"/>
+
+                                    <Label text="Graduación (%)" GridPane.rowIndex="5" GridPane.columnIndex="0"/>
+                                    <HBox spacing="6" GridPane.rowIndex="5" GridPane.columnIndex="1">
+                                        <TextField fx:id="txtCervezaGradMin" promptText="Mín"/>
+                                        <Label text="-" alignment="CENTER"/>
+                                        <TextField fx:id="txtCervezaGradMax" promptText="Máx"/>
+                                    </HBox>
+
+                                    <Label text="Existencia total" GridPane.rowIndex="6" GridPane.columnIndex="0"/>
+                                    <HBox spacing="6" GridPane.rowIndex="6" GridPane.columnIndex="1">
+                                        <TextField fx:id="txtCervezaExistMin" promptText="Mín"/>
+                                        <Label text="-" alignment="CENTER"/>
+                                        <TextField fx:id="txtCervezaExistMax" promptText="Máx"/>
+                                    </HBox>
+                                </GridPane>
+
+                                <HBox spacing="10" alignment="CENTER_RIGHT">
+                                    <Button text="Recargar" onAction="#onRecargarCervezas"/>
+                                    <Button text="Limpiar filtros" onAction="#onLimpiarFiltrosCerveza"/>
+                                </HBox>
+
+                                <TableView fx:id="tblCervezas" prefHeight="280">
+                                    <columns>
+                                        <TableColumn fx:id="colCerId" text="ID" prefWidth="70"/>
+                                        <TableColumn fx:id="colCerIdMarca" text="ID Marca" prefWidth="90"/>
+                                        <TableColumn fx:id="colCerNombre" text="Nombre" prefWidth="160"/>
+                                        <TableColumn fx:id="colCerAspecto" text="Aspecto" prefWidth="140"/>
+                                        <TableColumn fx:id="colCerProcedimientos" text="Procedimientos" prefWidth="220"/>
+                                        <TableColumn fx:id="colCerGraduacion" text="Graduación" prefWidth="110"/>
+                                        <TableColumn fx:id="colCerExistTotal" text="Existencia Total" prefWidth="140"/>
+                                    </columns>
+                                </TableView>
+                            </VBox>
+                        </content>
+                    </Tab>
+
+                    <Tab text="Existencias">
+                        <content>
+                            <VBox spacing="12">
+                                <padding>
+                                    <Insets top="10" right="10" bottom="10" left="10"/>
+                                </padding>
+                                <GridPane hgap="10" vgap="10">
+                                    <columnConstraints>
+                                        <ColumnConstraints percentWidth="25"/>
+                                        <ColumnConstraints percentWidth="75"/>
+                                    </columnConstraints>
+
+                                    <Label text="ID" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtExistId" promptText="Exacto" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+
+                                    <Label text="ID Expendio" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtExistIdExpendio" promptText="Exacto" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+
+                                    <Label text="Nombre expendio" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtExistNombreExpendio" promptText="Contiene" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+
+                                    <Label text="ID Presentación" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtExistIdPresentacion" promptText="Exacto" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
+
+                                    <Label text="Nombre presentación" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
+                                    <TextField fx:id="txtExistNombrePresentacion" promptText="Contiene" GridPane.rowIndex="4" GridPane.columnIndex="1"/>
+
+                                    <Label text="Cantidad" GridPane.rowIndex="5" GridPane.columnIndex="0"/>
+                                    <HBox spacing="6" GridPane.rowIndex="5" GridPane.columnIndex="1">
+                                        <TextField fx:id="txtExistCantidadMin" promptText="Mín"/>
+                                        <Label text="-" alignment="CENTER"/>
+                                        <TextField fx:id="txtExistCantidadMax" promptText="Máx"/>
+                                    </HBox>
+
+                                    <Label text="Fecha" GridPane.rowIndex="6" GridPane.columnIndex="0"/>
+                                    <HBox spacing="6" GridPane.rowIndex="6" GridPane.columnIndex="1">
+                                        <DatePicker fx:id="dpExistFechaDesde" promptText="Desde"/>
+                                        <Label text="-" alignment="CENTER"/>
+                                        <DatePicker fx:id="dpExistFechaHasta" promptText="Hasta"/>
+                                    </HBox>
+                                </GridPane>
+
+                                <HBox spacing="10" alignment="CENTER_RIGHT">
+                                    <Button text="Recargar" onAction="#onRecargarExistencias"/>
+                                    <Button text="Limpiar filtros" onAction="#onLimpiarFiltrosExistencia"/>
+                                </HBox>
+
+                                <TableView fx:id="tblExistencias" prefHeight="280">
+                                    <columns>
+                                        <TableColumn fx:id="colExistId" text="ID" prefWidth="70"/>
+                                        <TableColumn fx:id="colExistIdExpendio" text="ID Expendio" prefWidth="90"/>
+                                        <TableColumn fx:id="colExistNombreExpendio" text="Expendio" prefWidth="180"/>
+                                        <TableColumn fx:id="colExistIdPresentacion" text="ID Presentación" prefWidth="110"/>
+                                        <TableColumn fx:id="colExistNombrePresentacion" text="Presentación" prefWidth="220"/>
+                                        <TableColumn fx:id="colExistCantidad" text="Cantidad" prefWidth="90"/>
+                                        <TableColumn fx:id="colExistFecha" text="Fecha" prefWidth="120"/>
+                                    </columns>
+                                </TableView>
+                            </VBox>
+                        </content>
+                    </Tab>
+                </tabs>
+            </TabPane>
+        </VBox>
+    </children>
+</AnchorPane>


### PR DESCRIPTION
## Summary
- add a tabbed search view to filter cervezas and existencias by their table fields
- implement a controller that applies reactive predicates over DAO data and allows reloading and clearing filters
- expose the new search view from the menu bar and toolbar for quick access

## Testing
- `sh mvnw -q -DskipTests compile` *(fails: Network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68cb09d75c20832e94ccb0699fb05ae5