### PR TITLE
Agregar botones de listado a formularios pendientes

### DIFF
--- a/src/main/java/org/cerveza/cerveza/controller/CervezaFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/CervezaFormController.java
@@ -218,6 +218,23 @@ public class CervezaFormController {
     }
 
 
+    @FXML
+    public void onListar() {
+        try {
+            var resultados = dao.findAll();
+            tblCervezas.setItems(FXCollections.observableArrayList(resultados));
+            tblCervezas.setPlaceholder(new Label(""));
+            tblCervezas.getSelectionModel().clearSelection();
+            cervezaSeleccionada = null;
+            btnActualizar.setDisable(true);
+            btnEliminar.setDisable(true);
+            btnGuardar.setDisable(false);
+        } catch (Exception ex) {
+            showError("Error al listar: " + ex.getMessage());
+        }
+    }
+
+
     private void refreshTable() {
         // No cargar registros por defecto
         tblCervezas.setItems(FXCollections.observableArrayList());

--- a/src/main/java/org/cerveza/cerveza/controller/EnvaseFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/EnvaseFormController.java
@@ -86,6 +86,12 @@ public class EnvaseFormController {
         } catch (Exception e) { error("No se pudo eliminar: " + e.getMessage()); }
     }
 
+    @FXML
+    public void onListar() {
+        refreshTable();
+        clearForm();
+    }
+
     private void refreshTable() { tblEnvases.setItems(FXCollections.observableArrayList(dao.findAll())); }
     private void clearForm() {
         editingId = null;

--- a/src/main/java/org/cerveza/cerveza/controller/ExistenciaFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/ExistenciaFormController.java
@@ -148,4 +148,9 @@ public class ExistenciaFormController {
     private void error(String m) { Alert a = new Alert(Alert.AlertType.ERROR); a.setHeaderText("Validación"); a.setContentText(m); a.showAndWait(); }
     // record simple para combos
     public record IdName(int id, String name) { @Override public String toString(){ return name; } }
+
+    @FXML
+    private void onListar() {
+        refrescarTabla();
+    }
 }

--- a/src/main/java/org/cerveza/cerveza/controller/ExpendioFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/ExpendioFormController.java
@@ -113,6 +113,12 @@ public class ExpendioFormController {
         }
     }
 
+    @FXML
+    public void onListar() {
+        refrescarTabla();
+        limpiarForm();
+    }
+
     /* -------- helpers -------- */
 
     private void refrescarTabla() {

--- a/src/main/java/org/cerveza/cerveza/controller/MarcaFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/MarcaFormController.java
@@ -81,6 +81,12 @@ public class MarcaFormController {
         } catch (Exception e) { error("No se pudo eliminar: " + e.getMessage()); }
     }
 
+    @FXML
+    public void onListar() {
+        refreshTable();
+        clearForm();
+    }
+
     private void refreshTable() { tblMarcas.setItems(FXCollections.observableArrayList(dao.findAll())); }
     private void clearForm() {
         editingId = null;

--- a/src/main/java/org/cerveza/cerveza/controller/PresentacionFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/PresentacionFormController.java
@@ -115,4 +115,9 @@ public class PresentacionFormController {
 
     // pequeño record para combos
     public record IdName(int id, String name) { @Override public String toString(){ return name; } }
+
+    @FXML
+    private void onListar() {
+        refrescarTabla();
+    }
 }

--- a/src/main/java/org/cerveza/cerveza/controller/ProduccionFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/ProduccionFormController.java
@@ -124,6 +124,12 @@ public class ProduccionFormController {
         }
     }
 
+    @FXML
+    public void onListar() {
+        refrescarTabla();
+        limpiarForm();
+    }
+
     /* -------------------- helpers -------------------- */
 
     private void limpiarForm() {

--- a/src/main/java/org/cerveza/cerveza/controller/RecetaFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/RecetaFormController.java
@@ -117,6 +117,12 @@ public class RecetaFormController {
         }
     }
 
+    @FXML
+    private void onListar() {
+        refrescarTabla();
+        onNuevo();
+    }
+
     // Item simple para combos
         public record ComboItem(int id, String nombre) {
         @Override

--- a/src/main/java/org/cerveza/cerveza/controller/VentaFormController.java
+++ b/src/main/java/org/cerveza/cerveza/controller/VentaFormController.java
@@ -141,4 +141,10 @@ public class VentaFormController {
         public ComboItem(int id, String nombre) { this.id = id; this.nombre = nombre; }
         @Override public String toString() { return nombre + " (ID " + id + ")"; }
     }
+
+    @FXML
+    private void onListar() {
+        refrescarTabla();
+        onNuevo();
+    }
 }

--- a/src/main/resources/fxml/cerveza-form.fxml
+++ b/src/main/resources/fxml/cerveza-form.fxml
@@ -55,9 +55,10 @@
 
 
             <HBox alignment="CENTER_RIGHT" spacing="10">
-            <Label fx:id="cmbIdBusqueda" text="Buscar por" />
-            <ComboBox fx:id="cmbBusqueda" prefWidth="150.0" promptText="Elige un campo..." />
-            <TextField fx:id="txtBusqueda" promptText="Corona" />
+                <Label fx:id="cmbIdBusqueda" text="Buscar por" />
+                <ComboBox fx:id="cmbBusqueda" prefWidth="150.0" promptText="Elige un campo..." />
+                <TextField fx:id="txtBusqueda" promptText="Corona" />
+                <Button fx:id="btnListar" onAction="#onListar" text="Listar" />
                 <Button onAction="#onNuevo" text="Nuevo" />
                 <Button fx:id="btnGuardar" onAction="#onGuardar" text="Guardar" />
                 <Button onAction="#onLimpiar" text="Limpiar" />

--- a/src/main/resources/fxml/envase-form.fxml
+++ b/src/main/resources/fxml/envase-form.fxml
@@ -28,6 +28,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo" onAction="#onNuevo" fx:id="btnNuevo"/>
             <Button text="Guardar" onAction="#onGuardar" fx:id="btnGuardar"/>
             <Button text="Eliminar" onAction="#onEliminar" fx:id="btnEliminar"/>

--- a/src/main/resources/fxml/existencia-form.fxml
+++ b/src/main/resources/fxml/existencia-form.fxml
@@ -27,6 +27,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo" onAction="#onNuevo" fx:id="btnNuevo"/>
             <Button text="Guardar" onAction="#onGuardar" fx:id="btnGuardar"/>
             <Button text="Eliminar" onAction="#onEliminar" fx:id="btnEliminar"/>

--- a/src/main/resources/fxml/expendio-form.fxml
+++ b/src/main/resources/fxml/expendio-form.fxml
@@ -32,6 +32,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo"   onAction="#onNuevo"   fx:id="btnNuevo"/>
             <Button text="Guardar" onAction="#onGuardar" fx:id="btnGuardar"/>
             <Button text="Eliminar" onAction="#onEliminar" fx:id="btnEliminar"/>

--- a/src/main/resources/fxml/marca-form.fxml
+++ b/src/main/resources/fxml/marca-form.fxml
@@ -25,6 +25,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo" onAction="#onNuevo" fx:id="btnNuevo"/>
             <Button text="Guardar" onAction="#onGuardar" fx:id="btnGuardar"/>
             <Button text="Eliminar" onAction="#onEliminar" fx:id="btnEliminar"/>

--- a/src/main/resources/fxml/presentacion-form.fxml
+++ b/src/main/resources/fxml/presentacion-form.fxml
@@ -21,6 +21,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo" onAction="#onNuevo" fx:id="btnNuevo"/>
             <Button text="Guardar" onAction="#onGuardar" fx:id="btnGuardar"/>
             <Button text="Eliminar" onAction="#onEliminar" fx:id="btnEliminar"/>

--- a/src/main/resources/fxml/produccion-form.fxml
+++ b/src/main/resources/fxml/produccion-form.fxml
@@ -26,6 +26,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo"   fx:id="btnNuevo"   onAction="#onNuevo"/>
             <Button text="Guardar" fx:id="btnGuardar" onAction="#onGuardar"/>
             <Button text="Eliminar" fx:id="btnEliminar" onAction="#onEliminar"/>

--- a/src/main/resources/fxml/receta-form.fxml
+++ b/src/main/resources/fxml/receta-form.fxml
@@ -24,6 +24,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo" onAction="#onNuevo" fx:id="btnNuevo"/>
             <Button text="Guardar" onAction="#onGuardar" fx:id="btnGuardar"/>
             <Button text="Eliminar" onAction="#onEliminar" fx:id="btnEliminar"/>

--- a/src/main/resources/fxml/venta-form.fxml
+++ b/src/main/resources/fxml/venta-form.fxml
@@ -27,6 +27,7 @@
         </GridPane>
 
         <HBox spacing="10" alignment="CENTER_RIGHT">
+            <Button text="Listar" onAction="#onListar"/>
             <Button text="Nuevo" onAction="#onNuevo" fx:id="btnNuevo"/>
             <Button text="Guardar" onAction="#onGuardar" fx:id="btnGuardar"/>
             <Button text="Eliminar" onAction="#onEliminar" fx:id="btnEliminar"/>


### PR DESCRIPTION
## Summary
- agregar botones "Listar" en las vistas de cerveza, marca, envase, producción, expendio, existencia, presentación, receta y venta
- conectar los botones nuevos con métodos @FXML que reutilizan la lógica de refresco de cada formulario
- ajustar el controlador de cerveza para consultar todos los registros y restablecer el estado de la tabla al listar

## Testing
- `mvn -q test` *(falla: Network is unreachable al descargar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68d44a342760832ebab4c7d304334a38